### PR TITLE
Fix pagination skip logic

### DIFF
--- a/src/Dotnet.Template.Infrastructure/Pagination/QueryableExtensions.cs
+++ b/src/Dotnet.Template.Infrastructure/Pagination/QueryableExtensions.cs
@@ -10,20 +10,24 @@ public static class QueryableExtensions
     // The default behavior of this method is to return everything from the query.
     public static async Task<PaginationResult<T>> ToPagedQueryAsync<T>(this IQueryable<T> query, int? pageNumber, int? pageSize)
     {
-        int TotalRecords = await query.CountAsync();
+        int totalRecords = await query.CountAsync();
 
-        if (pageSize is not null)
-            query = query.Take((int)pageSize);
-
-        if (pageNumber is not null)
-            query = query.Skip(pageSize ?? 0 * ((int)pageNumber - 1));
+        if (pageNumber is not null && pageSize is not null)
+        {
+            int skip = pageSize.Value * (pageNumber.Value - 1);
+            query = query.Skip(skip).Take(pageSize.Value);
+        }
+        else if (pageSize is not null)
+        {
+            query = query.Take(pageSize.Value);
+        }
 
         List<T> result = await query.ToListAsync();
 
         return new PaginationResult<T>
         {
             Page = result,
-            TotalRecords = TotalRecords,
+            TotalRecords = totalRecords,
             TotalDisplayRecords = result.Count
         };
     }


### PR DESCRIPTION
## Summary
- fix incorrect skip calculation in `ToPagedQueryAsync`

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438ac63fc0832abb2bcda4dd5012d1