### PR TITLE
Add pagination tests project

### DIFF
--- a/dotnet-template.sln
+++ b/dotnet-template.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.Template.Domain", "s
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.Template.Infrastructure", "src\Dotnet.Template.Infrastructure\Dotnet.Template.Infrastructure.csproj", "{0212B1F1-C0BB-420B-A6FB-C4C26552A253}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A16F4E22-D8F6-481A-824A-AC624AF4F6B1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dotnet.Template.Tests", "tests\Dotnet.Template.Tests\Dotnet.Template.Tests.csproj", "{0820E643-B3AB-448C-9100-86C85497E270}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,15 +38,20 @@ Global
 		{2ADE26C3-D97F-43F1-AFC8-9213108F54B1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2ADE26C3-D97F-43F1-AFC8-9213108F54B1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2ADE26C3-D97F-43F1-AFC8-9213108F54B1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0212B1F1-C0BB-420B-A6FB-C4C26552A253}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0212B1F1-C0BB-420B-A6FB-C4C26552A253}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0212B1F1-C0BB-420B-A6FB-C4C26552A253}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0212B1F1-C0BB-420B-A6FB-C4C26552A253}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{8F345AF8-127D-4E6E-83BE-0CB29263FF41} = {342EDB7A-ED24-4DD9-822C-9374321A8CC9}
-		{2BACEB28-B32A-4D49-868F-D452F527FE5E} = {342EDB7A-ED24-4DD9-822C-9374321A8CC9}
-		{2ADE26C3-D97F-43F1-AFC8-9213108F54B1} = {342EDB7A-ED24-4DD9-822C-9374321A8CC9}
-		{0212B1F1-C0BB-420B-A6FB-C4C26552A253} = {342EDB7A-ED24-4DD9-822C-9374321A8CC9}
-	EndGlobalSection
+                {0212B1F1-C0BB-420B-A6FB-C4C26552A253}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0212B1F1-C0BB-420B-A6FB-C4C26552A253}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0212B1F1-C0BB-420B-A6FB-C4C26552A253}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0212B1F1-C0BB-420B-A6FB-C4C26552A253}.Release|Any CPU.Build.0 = Release|Any CPU
+                {0820E643-B3AB-448C-9100-86C85497E270}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {0820E643-B3AB-448C-9100-86C85497E270}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {0820E643-B3AB-448C-9100-86C85497E270}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {0820E643-B3AB-448C-9100-86C85497E270}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(NestedProjects) = preSolution
+                {8F345AF8-127D-4E6E-83BE-0CB29263FF41} = {342EDB7A-ED24-4DD9-822C-9374321A8CC9}
+                {2BACEB28-B32A-4D49-868F-D452F527FE5E} = {342EDB7A-ED24-4DD9-822C-9374321A8CC9}
+                {2ADE26C3-D97F-43F1-AFC8-9213108F54B1} = {342EDB7A-ED24-4DD9-822C-9374321A8CC9}
+                {0212B1F1-C0BB-420B-A6FB-C4C26552A253} = {342EDB7A-ED24-4DD9-822C-9374321A8CC9}
+                {0820E643-B3AB-448C-9100-86C85497E270} = {A16F4E22-D8F6-481A-824A-AC624AF4F6B1}
+        EndGlobalSection
 EndGlobal

--- a/src/Dotnet.Template.Infrastructure/Pagination/QueryableExtensions.cs
+++ b/src/Dotnet.Template.Infrastructure/Pagination/QueryableExtensions.cs
@@ -13,10 +13,14 @@ public static class QueryableExtensions
         int TotalRecords = await query.CountAsync();
 
         if (pageSize is not null)
+        {
             query = query.Take((int)pageSize);
+        }
 
         if (pageNumber is not null)
-            query = query.Skip(pageSize ?? 0 * ((int)pageNumber - 1));
+        {
+            query = query.Skip(((pageSize ?? 0) * ((int)pageNumber - 1)));
+        }
 
         List<T> result = await query.ToListAsync();
 

--- a/tests/Dotnet.Template.Tests/Dotnet.Template.Tests.csproj
+++ b/tests/Dotnet.Template.Tests/Dotnet.Template.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.7.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dotnet.Template.Infrastructure\Dotnet.Template.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Dotnet.Template.Tests/PaginationTests.cs
+++ b/tests/Dotnet.Template.Tests/PaginationTests.cs
@@ -1,0 +1,99 @@
+using Dotnet.Template.Infrastructure.Pagination;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Dotnet.Template.Tests;
+
+public class PaginationTests
+{
+    private class Item
+    {
+        public int Id { get; set; }
+    }
+
+    private class TestDbContext(DbContextOptions<TestDbContext> options) : DbContext(options)
+    {
+        public DbSet<Item> Items => Set<Item>();
+    }
+
+    private static async Task<TestDbContext> CreateContextAsync(IEnumerable<Item> seed)
+    {
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        var context = new TestDbContext(options);
+        context.Items.AddRange(seed);
+        await context.SaveChangesAsync();
+        return context;
+    }
+
+    [Fact]
+    public async Task Returns_first_page_when_page_number_and_size_provided()
+    {
+        var items = Enumerable.Range(1, 20).Select(i => new Item { Id = i });
+        await using var context = await CreateContextAsync(items);
+
+        var result = await context.Items.OrderBy(i => i.Id).AsQueryable()
+            .ToPagedQueryAsync(1, 5);
+
+        Assert.Equal(20, result.TotalRecords);
+        Assert.Equal(5, result.TotalDisplayRecords);
+        Assert.Equal(new[] { 1, 2, 3, 4, 5 }, result.Page!.Select(i => i.Id));
+    }
+
+    [Fact]
+    public async Task Returns_second_page_based_on_page_size()
+    {
+        var items = Enumerable.Range(1, 12).Select(i => new Item { Id = i });
+        await using var context = await CreateContextAsync(items);
+
+        var result = await context.Items.OrderBy(i => i.Id).AsQueryable()
+            .ToPagedQueryAsync(2, 5);
+
+        Assert.Equal(12, result.TotalRecords);
+        Assert.Equal(5, result.TotalDisplayRecords);
+        Assert.Equal(new[] { 6, 7, 8, 9, 10 }, result.Page!.Select(i => i.Id));
+    }
+
+    [Fact]
+    public async Task Handles_null_page_size_by_returning_all_items()
+    {
+        var items = Enumerable.Range(1, 3).Select(i => new Item { Id = i });
+        await using var context = await CreateContextAsync(items);
+
+        var result = await context.Items.OrderBy(i => i.Id).AsQueryable()
+            .ToPagedQueryAsync(1, null);
+
+        Assert.Equal(3, result.TotalRecords);
+        Assert.Equal(3, result.TotalDisplayRecords);
+        Assert.Equal(new[] { 1, 2, 3 }, result.Page!.Select(i => i.Id));
+    }
+
+    [Fact]
+    public async Task Handles_null_page_number_without_skipping()
+    {
+        var items = Enumerable.Range(1, 4).Select(i => new Item { Id = i });
+        await using var context = await CreateContextAsync(items);
+
+        var result = await context.Items.OrderBy(i => i.Id).AsQueryable()
+            .ToPagedQueryAsync(null, 2);
+
+        Assert.Equal(4, result.TotalRecords);
+        Assert.Equal(2, result.TotalDisplayRecords);
+        Assert.Equal(new[] { 1, 2 }, result.Page!.Select(i => i.Id));
+    }
+
+    [Fact]
+    public async Task Returns_empty_page_when_page_exceeds_data()
+    {
+        var items = Enumerable.Range(1, 5).Select(i => new Item { Id = i });
+        await using var context = await CreateContextAsync(items);
+
+        var result = await context.Items.OrderBy(i => i.Id).AsQueryable()
+            .ToPagedQueryAsync(3, 5);
+
+        Assert.Equal(5, result.TotalRecords);
+        Assert.Empty(result.Page!);
+        Assert.Equal(0, result.TotalDisplayRecords);
+    }
+}


### PR DESCRIPTION
## Summary
- add xUnit test project `Dotnet.Template.Tests`
- cover `QueryableExtensions.ToPagedQueryAsync` behavior
- fix skip logic in `QueryableExtensions`
- hook test project into solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438c84314c832aa93abd0ef88c1afc