### PR TITLE
Fix pagination skip logic

### DIFF
--- a/src/Dotnet.Template.Infrastructure/Pagination/QueryableExtensions.cs
+++ b/src/Dotnet.Template.Infrastructure/Pagination/QueryableExtensions.cs
@@ -15,8 +15,8 @@ public static class QueryableExtensions
         if (pageSize is not null)
             query = query.Take((int)pageSize);
 
-        if (pageNumber is not null)
-            query = query.Skip(pageSize ?? 0 * ((int)pageNumber - 1));
+        if (pageNumber is not null && pageSize is not null)
+            query = query.Skip(((int)pageNumber - 1) * (int)pageSize);
 
         List<T> result = await query.ToListAsync();
 


### PR DESCRIPTION
## Summary
- correct pagination skip expression in `QueryableExtensions`

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438c6407c8832aac4790ebbcea6c44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected pagination logic to ensure accurate page results when both page number and page size are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->